### PR TITLE
Fix invalid memory access in polynomial generator

### DIFF
--- a/src/emsa/polynomial.cpp
+++ b/src/emsa/polynomial.cpp
@@ -333,7 +333,7 @@ namespace POLY{
     for(vit=vb.begin();vit!=vb.end();vit++){
       if((*vit).has(seed)) return *vit;;
     }
-    return *vit;
+    return polynomial();
   }
   bool is_in(const monomial & m, const vector<monomial> & vm){
     vector<monomial>::const_iterator vit;


### PR DESCRIPTION
Using Valgrind I have found that under some circumstances, the C++ code that generates the polynomials accesses invalid memory addresses, which is undefined behavior.
This patch prevents such events.
Patch written by @vtajti