### PR TITLE
Fix various issues around the Fortran programs

### DIFF
--- a/msa.py
+++ b/msa.py
@@ -274,7 +274,7 @@ cl('''cp ./src/fit.x ./
 rm fit.x
 mv ./src/basis.f90 ./
 mv ./src/gradient.f90 ./
-cp ./src/Makefile ./ '''
+cp -p ./src/Makefile ./ '''
 )
 
 g = open('pes_shell.f90','w')


### PR DESCRIPTION
These commits fix various issues/warnings in and around the Fortran programs written by msa.py.

1. The fitter could not be compiled with gfortran due to non-standard use of .eq.
2. Undefined behavior and nonsense results in the fitter due to uninitialized variables
3. No check for LLS solver failure in the fitter
4. Unused variables
5. Elements with 2-letter symbols (eg. Br) were not handled
6. Make occasionally emitted clock skew warnings due to Makefile copying without timestamp preservation