### PR TITLE
msa.py overhaul, part 1

### DIFF
--- a/msa.py
+++ b/msa.py
@@ -47,7 +47,7 @@ perl postemsa.pl ''' + arg + '''
 perl derivative.pl ''' + arg
 )
 
-train_x = input('Please input the name of the data file: ')
+train_x = input('Please input the name of the fitting set file: ')
 
 f = open(train_x)
 nol = 0
@@ -288,7 +288,7 @@ cd src
 make'''
 )
 
-print("Fitting... (This might take time) \n")
+print("Fitting... (This might take a while) \n")
 
 cl('''cp ./src/fit.x ./
 ./fit.x '''+train_x+'''

--- a/msa.py
+++ b/msa.py
@@ -4,7 +4,7 @@ import os
 import shlex
 def cl(command):
     #ip::string, command line as string input
-    #op::string, return value is the output of command line
+    #op::integer, return value is the return value of the command line
     #Notice, each time when cl is called, cl starts from current directory.
     #Use three \' if you want to input multiple lines
     #String emptiness detection is taken from https://stackoverflow.com/a/55747410
@@ -15,7 +15,9 @@ def cl(command):
     if (not "".__eq__(stderr_str)) and (not stderr_str.isspace()):
         print('The command has also written to stderr:')
         print(stderr_str)
-    return stdout_str
+    if p.returncode != 0:
+        print((command + ' returned with return code: '+ str(p.returncode)))
+    return p.returncode
 
 order = input('Please input the maximum order of the polynomial: ')
 symmetry = input('Please input the permutation symmetry of the molecule: ')

--- a/msa.py
+++ b/msa.py
@@ -7,7 +7,6 @@ def cl(command):
     #op::string, return value is the output of command line
     #Notice, each time when cl is called, cl starts from current directory.
     #Use three \' if you want to input multiple lines
-    arg = shlex.split(command)
     p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True)
     (output, err) = p.communicate()
     print(output)

--- a/msa.py
+++ b/msa.py
@@ -7,10 +7,14 @@ def cl(command):
     #op::string, return value is the output of command line
     #Notice, each time when cl is called, cl starts from current directory.
     #Use three \' if you want to input multiple lines
+    #String emptiness detection is taken from https://stackoverflow.com/a/55747410
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, universal_newlines=True)
     (stdout_str, stderr_str) = p.communicate()
-    print(stdout_str)
-    print(stderr_str)
+    if (not "".__eq__(stdout_str)) and (not stdout_str.isspace()):
+        print(stdout_str)
+    if (not "".__eq__(stderr_str)) and (not stderr_str.isspace()):
+        print('The command has also written to stderr:')
+        print(stderr_str)
     return stdout_str
 
 order = input('Please input the maximum order of the polynomial: ')

--- a/msa.py
+++ b/msa.py
@@ -21,7 +21,6 @@ def cl(command):
 
 order = input('Please input the maximum order of the polynomial: ')
 symmetry = input('Please input the permutation symmetry of the molecule: ')
-train_x = input('Please input the name of the data file: ')
 arg = order +' '+ symmetry
 
 print("")
@@ -47,6 +46,8 @@ cd src
 perl postemsa.pl ''' + arg + '''
 perl derivative.pl ''' + arg
 )
+
+train_x = input('Please input the name of the data file: ')
 
 f = open(train_x)
 nol = 0

--- a/msa.py
+++ b/msa.py
@@ -5,8 +5,8 @@ import shlex
 def cl(command):
     #ip::string, command line as string input
     #op::string, return value is the output of command line
-    #Notice, each time when change directly, cl starts from currect directory.
-    #Use three \' if you want to input multiple line
+    #Notice, each time when cl is called, cl starts from current directory.
+    #Use three \' if you want to input multiple lines
     arg = shlex.split(command)
     p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True)
     (output, err) = p.communicate()

--- a/msa.py
+++ b/msa.py
@@ -25,19 +25,23 @@ train_x = input('Please input the name of the data file: ')
 arg = order +' '+ symmetry
 
 print("")
-print("Generating the fitting bases... (This might take time) \n")
-
+print("Compiling the fitting base generator...")
 cl('''
 cd src
 cd emsa
 make
 cp msa ../ '''
 )
+
+print("Generating the fitting bases...")
+print("This might take hours for larger systems, especially if they have a lot of permutational symmetry.")
 cl('''
 cd src
 ./msa '''+ arg +  '''
 '''
 )
+
+print("Generating the Fortran source code from the fitting bases...")
 cl('''
 cd src
 perl postemsa.pl ''' + arg + '''

--- a/msa.py
+++ b/msa.py
@@ -7,10 +7,11 @@ def cl(command):
     #op::string, return value is the output of command line
     #Notice, each time when cl is called, cl starts from current directory.
     #Use three \' if you want to input multiple lines
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True)
-    (output, err) = p.communicate()
-    print(output)
-    return output
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, universal_newlines=True)
+    (stdout_str, stderr_str) = p.communicate()
+    print(stdout_str)
+    print(stderr_str)
+    return stdout_str
 
 order = input('Please input the maximum order of the polynomial: ')
 symmetry = input('Please input the permutation symmetry of the molecule: ')

--- a/msa.py
+++ b/msa.py
@@ -31,9 +31,15 @@ cl('''
 cd src
 cd emsa
 make
-cp msa ../
-cd ../
+cp msa ../ '''
+)
+cl('''
+cd src
 ./msa '''+ arg +  '''
+'''
+)
+cl('''
+cd src
 perl postemsa.pl ''' + arg + '''
 perl derivative.pl ''' + arg
 )

--- a/msa.py
+++ b/msa.py
@@ -25,27 +25,39 @@ arg = order +' '+ symmetry
 
 print("")
 print("Compiling the fitting base generator...")
-cl('''
+returncode = cl('''
 cd src
 cd emsa
 make
 cp msa ../ '''
 )
+if returncode != 0:
+    print("Failed to compile fitting base generator!\n")
+    print("Please check the output above, maybe try running reset, and try again!\n")
+    quit()
 
 print("Generating the fitting bases...")
 print("This might take hours for larger systems, especially if they have a lot of permutational symmetry.")
-cl('''
+returncode = cl('''
 cd src
 ./msa '''+ arg +  '''
 '''
 )
+if returncode != 0:
+    print("Failed to generate fitting bases!\n")
+    print("Please check the output above, maybe try running reset, and try again!\n")
+    quit()
 
 print("Generating the Fortran source code from the fitting bases...")
-cl('''
+returncode = cl('''
 cd src
 perl postemsa.pl ''' + arg + '''
 perl derivative.pl ''' + arg
 )
+if returncode != 0:
+    print("Failed to generate Fortran source code!\n")
+    print("Please check the output above and try again!\n")
+    quit()
 
 train_x = input('Please input the name of the fitting set file: ')
 
@@ -109,10 +121,14 @@ else:
     wt = line.split()[1]
 
 print("Splicing values into gradient.f90...")
-cl('''cd src
+returncode = cl('''cd src
 sed 's/a = 2.0d0/a = ''' + a0 + '''/g' gradient.f90 > temp.f90
 mv temp.f90 gradient.f90
 ''')
+if returncode != 0:
+    print("Failed to splice values into gradient.f90!\n")
+    print("Please check the output above and try again!\n")
+    quit()
 
 print("Writing src/fit.f90...")
 g = open('./src/fit.f90','w')
@@ -283,20 +299,27 @@ end program
 g.close() #Must close the file handle if you want to compile this file.
 
 print("Compiling fit.f90...")
-cl('''
+returncode = cl('''
 cd src
 make'''
 )
+if returncode != 0:
+    print("Failed to compile src/fit.f90!\n")
+    print("Please check the output above and try again!\n")
+    quit()
 
 print("Fitting... (This might take a while) \n")
-
-cl('''cp ./src/fit.x ./
+returncode = cl('''cp ./src/fit.x ./
 ./fit.x '''+train_x+'''
 rm fit.x
 mv ./src/basis.f90 ./
 mv ./src/gradient.f90 ./
 cp -p ./src/Makefile ./ '''
 )
+if returncode != 0:
+    print("Failed to run fit.x!\n")
+    print("Please check the output above and try again!\n")
+    quit()
 
 print("Writing pes_shell.f90...")
 g = open('pes_shell.f90','w')
@@ -473,9 +496,13 @@ end program
 g.close()
 
 print("Compiling test.f90...")
-cl('''make test.x
+returncode = cl('''make test.x
 cp ./src/test.xyz ./'''
 )
+if returncode != 0:
+    print("Failed to compile test.f90!\n")
+    print("Please check the output above and try again!\n")
+    quit()
 
 print ('4. In order to run the test program, use command:')
 print ('./test.x test.xyz \n')

--- a/msa.py
+++ b/msa.py
@@ -108,11 +108,13 @@ else:
     a0 = line.split()[0]
     wt = line.split()[1]
 
+print("Splicing values into gradient.f90...")
 cl('''cd src
 sed 's/a = 2.0d0/a = ''' + a0 + '''/g' gradient.f90 > temp.f90
 mv temp.f90 gradient.f90
 ''')
 
+print("Writing src/fit.f90...")
 g = open('./src/fit.f90','w')
 g.write('''program fit
 use basis
@@ -279,6 +281,8 @@ implicit none
 end program
 ''')
 g.close() #Must close the file handle if you want to compile this file.
+
+print("Compiling fit.f90...")
 cl('''
 cd src
 make'''
@@ -294,6 +298,7 @@ mv ./src/gradient.f90 ./
 cp -p ./src/Makefile ./ '''
 )
 
+print("Writing pes_shell.f90...")
 g = open('pes_shell.f90','w')
 g.write('''module pes_shell
 use basis
@@ -405,6 +410,7 @@ end module pes_shell
 ''')
 g.close()
 
+print("Writing test.f90...")
 g = open("test.f90","w")
 g.write('''
 program main
@@ -466,6 +472,7 @@ end program
 ''')
 g.close()
 
+print("Compiling test.f90...")
 cl('''make test.x
 cp ./src/test.xyz ./'''
 )


### PR DESCRIPTION
This PR contains mostly user experience and robustness improvements, such as printing a message when a particular operation is started and trying to check if an operation succeeded before continuing.

1. If the executed command writes to stderr, that is also captured and printed, with a notice.
2. Both the stdout and stderr are checked for emptiness, and printing is skipped if they are empty. This avoids bloating the output with empty lines.
3. `cl` is modified to return the return code (integer) instead of a sting containing stdout.
4. The return code from `cl` is now checked after every call. If it is non-zero, `msa.py` now prints an error message and exit. Note that there may be some errors that are still not caught by this, if multiple commands are executed in a single call to `cl`.
5. The user is only asked to provide the path of the fitting set after the Perl scripts are done generating code.